### PR TITLE
Fix memory issues

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -622,7 +622,7 @@ public:
         \see CopyFrom()
     */
     template <typename SourceAllocator>
-    GenericValue(const GenericValue<Encoding,SourceAllocator>& rhs, Allocator& allocator, bool copyConstStrings = false) {
+    [[deprecated("missing handling of memory allocation errors")]] GenericValue(const GenericValue<Encoding,SourceAllocator>& rhs, Allocator& allocator, bool copyConstStrings = false) {
         switch (rhs.GetType()) {
         case kObjectType: {
                 SizeType count = rhs.data_.o.size;
@@ -1245,13 +1245,20 @@ public:
         ObjectData& o = data_.o;
         if (o.size >= o.capacity) {
             if (o.capacity == 0) {
+                auto ptr = reinterpret_cast<Member*>(allocator.Malloc(kDefaultObjectCapacity * sizeof(Member)));
+                if (!ptr)
+                    return *this;
                 o.capacity = kDefaultObjectCapacity;
-                SetMembersPointer(reinterpret_cast<Member*>(allocator.Malloc(o.capacity * sizeof(Member))));
+                SetMembersPointer(ptr);
             }
             else {
                 SizeType oldCapacity = o.capacity;
-                o.capacity += (oldCapacity + 1) / 2; // grow by factor 1.5
-                SetMembersPointer(reinterpret_cast<Member*>(allocator.Realloc(GetMembersPointer(), oldCapacity * sizeof(Member), o.capacity * sizeof(Member))));
+                SizeType newCapacity = o.capacity + (oldCapacity + 1) / 2; // grow by factor 1.5
+                auto ptr = reinterpret_cast<Member*>(allocator.Realloc(GetMembersPointer(), oldCapacity * sizeof(Member), newCapacity * sizeof(Member)));
+                if (!ptr)
+                    return *this;
+                o.capacity = newCapacity;
+                SetMembersPointer(ptr);
             }
         }
         Member* members = GetMembersPointer();
@@ -1999,7 +2006,10 @@ private:
         if (count) {
             GenericValue* e = static_cast<GenericValue*>(allocator.Malloc(count * sizeof(GenericValue)));
             SetElementsPointer(e);
-            std::memcpy(e, values, count * sizeof(GenericValue));
+            if (e)
+                std::memcpy(e, values, count * sizeof(GenericValue));
+            else
+                count = 0;
         }
         else
             SetElementsPointer(0);
@@ -2012,7 +2022,10 @@ private:
         if (count) {
             Member* m = static_cast<Member*>(allocator.Malloc(count * sizeof(Member)));
             SetMembersPointer(m);
-            std::memcpy(m, members, count * sizeof(Member));
+            if (m)
+                std::memcpy(m, members, count * sizeof(Member));
+            else
+                count = 0;
         }
         else
             SetMembersPointer(0);
@@ -2039,8 +2052,10 @@ private:
             str = static_cast<Ch *>(allocator.Malloc((s.length + 1) * sizeof(Ch)));
             SetStringPointer(str);
         }
-        std::memcpy(str, s, s.length * sizeof(Ch));
-        str[s.length] = '\0';
+        if (str) {
+            std::memcpy(str, s, s.length * sizeof(Ch));
+            str[s.length] = '\0';
+        }
     }
 
     //! Assignment without calling destructor
@@ -2397,45 +2412,75 @@ private:
 
 public:
     // Implementation of Handler
-    bool Null() { new (stack_.template Push<ValueType>()) ValueType(); return true; }
-    bool Bool(bool b) { new (stack_.template Push<ValueType>()) ValueType(b); return true; }
-    bool Int(int i) { new (stack_.template Push<ValueType>()) ValueType(i); return true; }
-    bool Uint(unsigned i) { new (stack_.template Push<ValueType>()) ValueType(i); return true; }
-    bool Int64(int64_t i) { new (stack_.template Push<ValueType>()) ValueType(i); return true; }
-    bool Uint64(uint64_t i) { new (stack_.template Push<ValueType>()) ValueType(i); return true; }
-    bool Double(double d) { new (stack_.template Push<ValueType>()) ValueType(d); return true; }
+    bool Null() { auto ptr = stack_.template Push<ValueType>(); if (!ptr) return false; new (ptr) ValueType(); return true; }
+    bool Bool(bool b) { auto ptr = stack_.template Push<ValueType>(); if (!ptr) return false; new (ptr) ValueType(b); return true; }
+    bool Int(int i) { auto ptr = stack_.template Push<ValueType>(); if (!ptr) return false; new (ptr) ValueType(i); return true; }
+    bool Uint(unsigned i) { auto ptr = stack_.template Push<ValueType>(); if (!ptr) return false; new (ptr) ValueType(i); return true; }
+    bool Int64(int64_t i) { auto ptr = stack_.template Push<ValueType>(); if (!ptr) return false; new (ptr) ValueType(i); return true; }
+    bool Uint64(uint64_t i) { auto ptr = stack_.template Push<ValueType>(); if (!ptr) return false; new (ptr) ValueType(i); return true; }
+    bool Double(double d) { auto ptr = stack_.template Push<ValueType>(); if (!ptr) return false; new (ptr) ValueType(d); return true; }
 
     bool RawNumber(const Ch* str, SizeType length, bool copy) { 
-        if (copy) 
-            new (stack_.template Push<ValueType>()) ValueType(str, length, GetAllocator());
+        auto ptr = stack_.template Push<ValueType>();
+        if (!ptr)
+            return false;
+        if (copy) {
+            auto tptr = new (ptr) ValueType(str, length, GetAllocator());
+            if (tptr->data_.f.flags == ValueType::kCopyStringFlag && !RAPIDJSON_GETPOINTER(GenericValue::Ch, tptr->data_.s.str))
+                return false;
+        }
         else
-            new (stack_.template Push<ValueType>()) ValueType(str, length);
+            new (ptr) ValueType(str, length);
         return true;
     }
 
     bool String(const Ch* str, SizeType length, bool copy) { 
-        if (copy) 
-            new (stack_.template Push<ValueType>()) ValueType(str, length, GetAllocator());
+        auto ptr = stack_.template Push<ValueType>();
+        if (!ptr)
+            return false;
+        if (copy) {
+            auto tptr = new (ptr) ValueType(str, length, GetAllocator());
+            if (tptr->data_.f.flags == ValueType::kCopyStringFlag && !RAPIDJSON_GETPOINTER(GenericValue::Ch, tptr->data_.s.str))
+              return false;
+        }
         else
-            new (stack_.template Push<ValueType>()) ValueType(str, length);
+            new (ptr) ValueType(str, length);
         return true;
     }
 
-    bool StartObject() { new (stack_.template Push<ValueType>()) ValueType(kObjectType); return true; }
+    bool StartObject() {
+        auto ptr = stack_.template Push<ValueType>();
+        if (!ptr)
+            return false;
+        new (ptr) ValueType(kObjectType);
+        return true;
+    }
     
     bool Key(const Ch* str, SizeType length, bool copy) { return String(str, length, copy); }
 
     bool EndObject(SizeType memberCount) {
         typename ValueType::Member* members = stack_.template Pop<typename ValueType::Member>(memberCount);
-        stack_.template Top<ValueType>()->SetObjectRaw(members, memberCount, GetAllocator());
+        auto ptr = stack_.template Top<ValueType>();
+        ptr->SetObjectRaw(members, memberCount, GetAllocator());
+        if (memberCount && !RAPIDJSON_GETPOINTER(Member, ptr->data_.o.members))
+            return false;
         return true;
     }
 
-    bool StartArray() { new (stack_.template Push<ValueType>()) ValueType(kArrayType); return true; }
+    bool StartArray() {
+        auto ptr = stack_.template Push<ValueType>();
+        if (!ptr)
+            return false;
+        new (ptr) ValueType(kArrayType);
+        return true;
+    }
     
     bool EndArray(SizeType elementCount) {
         ValueType* elements = stack_.template Pop<ValueType>(elementCount);
-        stack_.template Top<ValueType>()->SetArrayRaw(elements, elementCount, GetAllocator());
+        auto ptr = stack_.template Top<ValueType>();
+        ptr->SetArrayRaw(elements, elementCount, GetAllocator());
+        if (elementCount && !RAPIDJSON_GETPOINTER(GenericValue, ptr->data_.a.elements))
+            return false;
         return true;
     }
 

--- a/include/rapidjson/internal/regex.h
+++ b/include/rapidjson/internal/regex.h
@@ -78,7 +78,7 @@ static const SizeType kRegexInvalidState = ~SizeType(0);  //!< Represents an inv
 static const SizeType kRegexInvalidRange = ~SizeType(0);
 
 template <typename Encoding, typename Allocator>
-class GenericRegexSearch;
+class [[deprecated("missing handling of memory allocation errors")]] GenericRegexSearch;
 
 //! Regular expression engine with subset of ECMAscript grammar.
 /*!
@@ -113,7 +113,7 @@ class GenericRegexSearch;
         https://swtch.com/~rsc/regexp/regexp1.html 
 */
 template <typename Encoding, typename Allocator = CrtAllocator>
-class GenericRegex {
+class [[deprecated("missing handling of memory allocation errors")]] GenericRegex {
 public:
     typedef Encoding EncodingType;
     typedef typename Encoding::Ch Ch;

--- a/include/rapidjson/internal/stack.h
+++ b/include/rapidjson/internal/stack.h
@@ -37,7 +37,7 @@ class Stack {
 public:
     // Optimization note: Do not allocate memory for stack_ in constructor.
     // Do it lazily when first Push() -> Expand() -> Resize().
-    Stack(Allocator* allocator, size_t stackCapacity) : allocator_(allocator), ownAllocator_(0), stack_(0), stackTop_(0), stackEnd_(0), initialCapacity_(stackCapacity) {
+    Stack(Allocator* allocator, size_t stackCapacity) : allocator_(allocator), ownAllocator_(0), stack_(0), stackTop_(0), stackEnd_(0), initialCapacity_(stackCapacity), allocationError_(false) {
     }
 
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS
@@ -47,7 +47,8 @@ public:
           stack_(rhs.stack_),
           stackTop_(rhs.stackTop_),
           stackEnd_(rhs.stackEnd_),
-          initialCapacity_(rhs.initialCapacity_)
+          initialCapacity_(rhs.initialCapacity_),
+          allocationError_(rhs.allocationError_)
     {
         rhs.allocator_ = 0;
         rhs.ownAllocator_ = 0;
@@ -55,6 +56,7 @@ public:
         rhs.stackTop_ = 0;
         rhs.stackEnd_ = 0;
         rhs.initialCapacity_ = 0;
+        rhs.allocationError_ = false;
     }
 #endif
 
@@ -74,6 +76,7 @@ public:
             stackTop_ = rhs.stackTop_;
             stackEnd_ = rhs.stackEnd_;
             initialCapacity_ = rhs.initialCapacity_;
+            allocationError_ = rhs.allocationError_;
 
             rhs.allocator_ = 0;
             rhs.ownAllocator_ = 0;
@@ -81,6 +84,7 @@ public:
             rhs.stackTop_ = 0;
             rhs.stackEnd_ = 0;
             rhs.initialCapacity_ = 0;
+            rhs.allocationError_ = 0;
         }
         return *this;
     }
@@ -93,6 +97,7 @@ public:
         internal::Swap(stackTop_, rhs.stackTop_);
         internal::Swap(stackEnd_, rhs.stackEnd_);
         internal::Swap(initialCapacity_, rhs.initialCapacity_);
+        internal::Swap(allocationError_, rhs.allocationError_);
     }
 
     void Clear() { stackTop_ = stack_; }
@@ -121,15 +126,20 @@ public:
     template<typename T>
     RAPIDJSON_FORCEINLINE T* Push(size_t count = 1) {
         Reserve<T>(count);
+        if (allocationError_)
+            return nullptr;
         return PushUnsafe<T>(count);
     }
 
     template<typename T>
     RAPIDJSON_FORCEINLINE T* PushUnsafe(size_t count = 1) {
+        if (allocationError_)
+            return nullptr;
         RAPIDJSON_ASSERT(stackTop_);
         RAPIDJSON_ASSERT(stackTop_ + sizeof(T) * count <= stackEnd_);
         T* ret = reinterpret_cast<T*>(stackTop_);
-        stackTop_ += sizeof(T) * count;
+        if (stackTop_)
+            stackTop_ += sizeof(T) * count;
         return ret;
     }
 
@@ -199,9 +209,15 @@ private:
 
     void Resize(size_t newCapacity) {
         const size_t size = GetSize();  // Backup the current size
-        stack_ = static_cast<char*>(allocator_->Realloc(stack_, GetCapacity(), newCapacity));
-        stackTop_ = stack_ + size;
-        stackEnd_ = stack_ + newCapacity;
+        char* newStack = static_cast<char*>(allocator_->Realloc(stack_, GetCapacity(), newCapacity));
+        if (newStack) {
+            stack_ = newStack;
+            stackTop_ = stack_ + size;
+            stackEnd_ = stack_ + newCapacity;
+        }
+        else {
+            allocationError_ = true;
+        }
     }
 
     void Destroy() {
@@ -219,6 +235,7 @@ private:
     char *stackTop_;
     char *stackEnd_;
     size_t initialCapacity_;
+    bool allocationError_;
 };
 
 } // namespace internal

--- a/include/rapidjson/memorybuffer.h
+++ b/include/rapidjson/memorybuffer.h
@@ -34,7 +34,7 @@ RAPIDJSON_NAMESPACE_BEGIN
     \note implements Stream concept
 */
 template <typename Allocator = CrtAllocator>
-struct GenericMemoryBuffer {
+struct [[deprecated("missing handling of memory allocation errors")]] GenericMemoryBuffer {
     typedef char Ch; // byte
 
     GenericMemoryBuffer(Allocator* allocator = 0, size_t capacity = kDefaultCapacity) : stack_(allocator, capacity) {}

--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -122,7 +122,10 @@ public:
 
     bool StartObject() {
         PrettyPrefix(kObjectType);
-        new (Base::level_stack_.template Push<typename Base::Level>()) typename Base::Level(false);
+        auto ptr = Base::level_stack_.template Push<typename Base::Level>();
+        if (!ptr)
+            return false;
+        new (ptr) typename Base::Level(false);
         return Base::WriteStartObject();
     }
 
@@ -156,7 +159,10 @@ public:
 
     bool StartArray() {
         PrettyPrefix(kArrayType);
-        new (Base::level_stack_.template Push<typename Base::Level>()) typename Base::Level(true);
+        auto ptr = Base::level_stack_.template Push<typename Base::Level>();
+        if (!ptr)
+            return false;
+        new (ptr) typename Base::Level(true);
         return Base::WriteStartArray();
     }
 

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -125,12 +125,12 @@ RAPIDJSON_MULTILINEMACRO_END
 // Forward declarations
 
 template <typename ValueType, typename Allocator>
-class GenericSchemaDocument;
+class [[deprecated("missing handling of memory allocation errors")]] GenericSchemaDocument;
 
 namespace internal {
 
 template <typename SchemaDocumentType>
-class Schema;
+class [[deprecated("missing handling of memory allocation errors")]] Schema;
 
 ///////////////////////////////////////////////////////////////////////////////
 // ISchemaValidator

--- a/include/rapidjson/stringbuffer.h
+++ b/include/rapidjson/stringbuffer.h
@@ -53,14 +53,27 @@ public:
     }
 #endif
 
-    void Put(Ch c) { *stack_.template Push<Ch>() = c; }
-    void PutUnsafe(Ch c) { *stack_.template PushUnsafe<Ch>() = c; }
+    void Put(Ch c) {
+        auto ptr = stack_.template Push<Ch>();
+        if (!ptr)
+            return;
+        *ptr = c;
+    }
+    void PutUnsafe(Ch c) {
+        auto ptr = stack_.template PushUnsafe<Ch>();
+        if (!ptr)
+            return;
+        *ptr = c;
+    }
     void Flush() {}
 
     void Clear() { stack_.Clear(); }
     void ShrinkToFit() {
         // Push and pop a null terminator. This is safe.
-        *stack_.template Push<Ch>() = '\0';
+        auto ptr = stack_.template Push<Ch>();
+        if (!ptr)
+            return;
+        *ptr = '\0';
         stack_.ShrinkToFit();
         stack_.template Pop<Ch>(1);
     }
@@ -72,7 +85,10 @@ public:
 
     const Ch* GetString() const {
         // Push and pop a null terminator. This is safe.
-        *stack_.template Push<Ch>() = '\0';
+        auto ptr = stack_.template Push<Ch>();
+        if (!ptr)
+            return nullptr;
+        *ptr = '\0';
         stack_.template Pop<Ch>(1);
 
         return stack_.template Bottom<Ch>();
@@ -109,7 +125,10 @@ inline void PutUnsafe(GenericStringBuffer<Encoding, Allocator>& stream, typename
 //! Implement specialized version of PutN() with memset() for better performance.
 template<>
 inline void PutN(GenericStringBuffer<UTF8<> >& stream, char c, size_t n) {
-    std::memset(stream.stack_.Push<char>(n), c, n * sizeof(c));
+    auto ptr = stream.stack_.Push<char>(n);
+    if (!ptr)
+        return;
+    std::memset(ptr, c, n * sizeof(c));
 }
 
 RAPIDJSON_NAMESPACE_END

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -216,7 +216,10 @@ public:
 
     bool StartObject() {
         Prefix(kObjectType);
-        new (level_stack_.template Push<Level>()) Level(false);
+        auto ptr = level_stack_.template Push<Level>();
+        if (!ptr)
+            return false;
+        new (ptr) Level(false);
         return WriteStartObject();
     }
 
@@ -240,7 +243,10 @@ public:
 
     bool StartArray() {
         Prefix(kArrayType);
-        new (level_stack_.template Push<Level>()) Level(true);
+        auto ptr = level_stack_.template Push<Level>();
+        if (!ptr)
+            return false;
+        new (ptr) Level(true);
         return WriteStartArray();
     }
 
@@ -510,6 +516,8 @@ private:
 template<>
 inline bool Writer<StringBuffer>::WriteInt(int i) {
     char *buffer = os_->Push(11);
+    if (!buffer)
+        return false;
     const char* end = internal::i32toa(i, buffer);
     os_->Pop(static_cast<size_t>(11 - (end - buffer)));
     return true;
@@ -518,6 +526,8 @@ inline bool Writer<StringBuffer>::WriteInt(int i) {
 template<>
 inline bool Writer<StringBuffer>::WriteUint(unsigned u) {
     char *buffer = os_->Push(10);
+    if (!buffer)
+        return false;
     const char* end = internal::u32toa(u, buffer);
     os_->Pop(static_cast<size_t>(10 - (end - buffer)));
     return true;
@@ -526,6 +536,8 @@ inline bool Writer<StringBuffer>::WriteUint(unsigned u) {
 template<>
 inline bool Writer<StringBuffer>::WriteInt64(int64_t i64) {
     char *buffer = os_->Push(21);
+    if (!buffer)
+        return false;
     const char* end = internal::i64toa(i64, buffer);
     os_->Pop(static_cast<size_t>(21 - (end - buffer)));
     return true;
@@ -534,6 +546,8 @@ inline bool Writer<StringBuffer>::WriteInt64(int64_t i64) {
 template<>
 inline bool Writer<StringBuffer>::WriteUint64(uint64_t u) {
     char *buffer = os_->Push(20);
+    if (!buffer)
+        return false;
     const char* end = internal::u64toa(u, buffer);
     os_->Pop(static_cast<size_t>(20 - (end - buffer)));
     return true;
@@ -562,6 +576,8 @@ inline bool Writer<StringBuffer>::WriteDouble(double d) {
     }
     
     char *buffer = os_->Push(25);
+    if (!buffer)
+        return false;
     char* end = internal::dtoa(d, buffer, maxDecimalPlaces_);
     os_->Pop(static_cast<size_t>(25 - (end - buffer)));
     return true;


### PR DESCRIPTION
Fix memory issues in case Allocator::Malloc returned a `NULL` pointer or throwed an exception. Issues are:
- Segmentation fault when dereferencing a `NULL` pointer
- Memory leak due to an incorrect internal state (e.g. tokenCount_),
  when a custom Allocator throwed an exception during `Malloc`